### PR TITLE
refactor: 트랜잭션 무효화 어노테이션 추가 및 트랜잭션 무효화를 위한 SimpleJpaRepository 메서드 오버라이딩

### DIFF
--- a/backend/src/main/java/feedzupzup/backend/admin/domain/AdminRepository.java
+++ b/backend/src/main/java/feedzupzup/backend/admin/domain/AdminRepository.java
@@ -8,9 +8,15 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
 
 @Repository
 public interface AdminRepository extends JpaRepository<Admin, Long> {
+
+    @Override
+    @Transactional(readOnly = true, propagation = Propagation.SUPPORTS)
+    Optional<Admin> findById(Long id);
 
     Optional<Admin> findByLoginId(final LoginId loginId);
 

--- a/backend/src/main/java/feedzupzup/backend/feedback/application/AdminFeedbackService.java
+++ b/backend/src/main/java/feedzupzup/backend/feedback/application/AdminFeedbackService.java
@@ -29,6 +29,7 @@ import feedzupzup.backend.feedback.dto.response.FeedbackItem;
 import feedzupzup.backend.feedback.dto.response.UpdateFeedbackCommentResponse;
 import feedzupzup.backend.feedback.exception.FeedbackException.DownloadJobNotCompletedException;
 import feedzupzup.backend.feedback.exception.FeedbackException.DownloadUrlNotGeneratedException;
+import feedzupzup.backend.global.annotation.NonTransactionalRead;
 import feedzupzup.backend.global.exception.ResourceException.ResourceNotFoundException;
 import feedzupzup.backend.global.log.BusinessActionLog;
 import feedzupzup.backend.organization.domain.OrganizationRepository;
@@ -48,7 +49,6 @@ import org.springframework.transaction.annotation.Transactional;
 @Slf4j
 @Service
 @RequiredArgsConstructor
-@Transactional(readOnly = true)
 public class AdminFeedbackService {
 
     private final AdminRepository adminRepository;
@@ -93,6 +93,7 @@ public class AdminFeedbackService {
         );
     }
 
+    @NonTransactionalRead
     public AdminFeedbackListResponse getFeedbackPage(
             final UUID organizationUuid,
             final int size,
@@ -154,6 +155,7 @@ public class AdminFeedbackService {
         feedBackRepository.deleteAllByOrganizationId(organizationId);
     }
 
+    @NonTransactionalRead
     public ClustersResponse getTopClusters(final UUID organizationUuid, final int limit) {
         if (!organizationRepository.existsOrganizationByUuid(organizationUuid)) {
             throw new ResourceNotFoundException("해당 organizationUuid(uuid = " + organizationUuid + ")로 찾을 수 없습니다.");
@@ -163,6 +165,7 @@ public class AdminFeedbackService {
         return ClustersResponse.from(clusterInfos);
     }
 
+    @NonTransactionalRead
     public ClusterFeedbacksResponse getFeedbacksByClusterId(final Long clusterId) {
         final EmbeddingCluster embeddingCluster = embeddingClusterRepository.findById(clusterId)
                 .orElseThrow(() -> new ResourceNotFoundException("해당 clusterid(id = " + clusterId + ")로 찾을 수 없습니다."));
@@ -184,6 +187,7 @@ public class AdminFeedbackService {
         return job.getJobId();
     }
 
+    @NonTransactionalRead
     public FeedbackDownloadJob getDownloadJobStatus(final String jobId) {
         final FeedbackDownloadJob job = feedbackDownloadJobStore.getById(jobId);
         if (job == null) {
@@ -192,6 +196,7 @@ public class AdminFeedbackService {
         return job;
     }
 
+    @NonTransactionalRead
     public String getDownloadUrl(final String jobId) {
         final FeedbackDownloadJob job = feedbackDownloadJobStore.getById(jobId);
         if (job == null) {

--- a/backend/src/main/java/feedzupzup/backend/feedback/domain/EmbeddingClusterRepository.java
+++ b/backend/src/main/java/feedzupzup/backend/feedback/domain/EmbeddingClusterRepository.java
@@ -1,9 +1,13 @@
 package feedzupzup.backend.feedback.domain;
 
 import java.util.Optional;
-import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
 
 public interface EmbeddingClusterRepository extends JpaRepository<EmbeddingCluster, Long> {
 
+    @Override
+    @Transactional(readOnly = true, propagation = Propagation.SUPPORTS)
+    Optional<EmbeddingCluster> findById(Long id);
 }

--- a/backend/src/main/java/feedzupzup/backend/global/annotation/NonTransactionalRead.java
+++ b/backend/src/main/java/feedzupzup/backend/global/annotation/NonTransactionalRead.java
@@ -1,0 +1,18 @@
+package feedzupzup.backend.global.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 단일 조회 메서드에 사용하는 어노테이션.
+ * 기존 트랜잭션이 있으면 참여하고, 없으면 트랜잭션 없이 실행합니다.
+ */
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@Transactional(readOnly = true, propagation = Propagation.SUPPORTS)
+public @interface NonTransactionalRead {
+}

--- a/backend/src/main/java/feedzupzup/backend/guest/application/GuestService.java
+++ b/backend/src/main/java/feedzupzup/backend/guest/application/GuestService.java
@@ -1,5 +1,6 @@
 package feedzupzup.backend.guest.application;
 
+import feedzupzup.backend.global.annotation.NonTransactionalRead;
 import feedzupzup.backend.global.domain.LockRepository;
 import feedzupzup.backend.global.util.CurrentDateTime;
 import feedzupzup.backend.guest.domain.guest.Guest;
@@ -22,7 +23,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
-@Transactional(readOnly = true)
 @RequiredArgsConstructor
 @Slf4j
 public class GuestService {
@@ -42,6 +42,7 @@ public class GuestService {
         guestRepository.save(guest);
     }
 
+    @NonTransactionalRead
     public MyFeedbackListResponse getMyFeedbackPage(
             final UUID organizationUuid,
             final GuestInfo guestInfo
@@ -51,6 +52,7 @@ public class GuestService {
         return MyFeedbackListResponse.fromHistory(writeHistories);
     }
 
+    @NonTransactionalRead
     public LikeHistoryResponse findGuestLikeHistories(
             final UUID organizationUuid,
             final GuestInfo guestInfo
@@ -60,6 +62,7 @@ public class GuestService {
         return LikeHistoryResponse.from(likeHistories);
     }
 
+    @NonTransactionalRead
     public boolean isSavedGuest(final UUID guestUuid) {
         return guestRepository.existsByGuestUuid(guestUuid);
     }

--- a/backend/src/main/java/feedzupzup/backend/notification/application/NotificationService.java
+++ b/backend/src/main/java/feedzupzup/backend/notification/application/NotificationService.java
@@ -2,6 +2,7 @@ package feedzupzup.backend.notification.application;
 
 import feedzupzup.backend.admin.domain.Admin;
 import feedzupzup.backend.admin.domain.AdminRepository;
+import feedzupzup.backend.global.annotation.NonTransactionalRead;
 import feedzupzup.backend.global.exception.ResourceException.ResourceNotFoundException;
 import feedzupzup.backend.notification.domain.Notification;
 import feedzupzup.backend.notification.domain.NotificationRepository;
@@ -15,7 +16,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
 @Service
-@Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class NotificationService {
 
@@ -31,6 +31,7 @@ public class NotificationService {
                 );
     }
 
+    @NonTransactionalRead
     public AlertsSettingResponse getAlertsSetting(final Long adminId) {
         final Admin admin = getAdminById(adminId);
         return AlertsSettingResponse.from(admin.isAlertsOn());

--- a/backend/src/main/java/feedzupzup/backend/organization/application/AdminOrganizationService.java
+++ b/backend/src/main/java/feedzupzup/backend/organization/application/AdminOrganizationService.java
@@ -4,6 +4,7 @@ import feedzupzup.backend.admin.domain.Admin;
 import feedzupzup.backend.admin.domain.AdminRepository;
 import feedzupzup.backend.category.application.OrganizationCategoryService;
 import feedzupzup.backend.feedback.application.AdminFeedbackService;
+import feedzupzup.backend.global.annotation.NonTransactionalRead;
 import feedzupzup.backend.global.exception.ResourceException.ResourceNotFoundException;
 import feedzupzup.backend.organization.domain.AdminOrganizationInfo;
 import feedzupzup.backend.organization.domain.Organization;
@@ -30,7 +31,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
-@Transactional(readOnly = true)
 public class AdminOrganizationService {
 
     private final OrganizationRepository organizationRepository;
@@ -71,6 +71,7 @@ public class AdminOrganizationService {
         return AdminCreateOrganizationResponse.from(savedOrganization);
     }
 
+    @NonTransactionalRead
     public List<AdminInquireOrganizationResponse> getOrganizationsInfo(final Long adminId) {
         final Admin admin = findAdminBy(adminId);
         final List<AdminOrganizationInfo> adminOrganizationInfos = organizationRepository.getAdminOrganizationInfos(

--- a/backend/src/main/java/feedzupzup/backend/organization/application/OrganizationStatisticService.java
+++ b/backend/src/main/java/feedzupzup/backend/organization/application/OrganizationStatisticService.java
@@ -1,5 +1,6 @@
 package feedzupzup.backend.organization.application;
 
+import feedzupzup.backend.global.annotation.NonTransactionalRead;
 import feedzupzup.backend.global.exception.ResourceException.ResourceNotFoundException;
 import feedzupzup.backend.organization.domain.FeedbackAmount;
 import feedzupzup.backend.organization.domain.Organization;
@@ -14,12 +15,12 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
-@Transactional(readOnly = true)
 public class OrganizationStatisticService {
 
     private final OrganizationRepository organizationRepository;
     private final OrganizationStatisticRepository organizationStatisticRepository;
 
+    @NonTransactionalRead
     public OrganizationStatisticResponse getStatistic(final UUID organizationUuid) {
         final Organization organization = findOrganizationBy(organizationUuid);
         final FeedbackAmount feedbackAmount = organizationStatisticRepository.findFeedbackAmountByOrganizationId(organization.getId());

--- a/backend/src/main/java/feedzupzup/backend/organization/application/UserOrganizationService.java
+++ b/backend/src/main/java/feedzupzup/backend/organization/application/UserOrganizationService.java
@@ -1,5 +1,6 @@
 package feedzupzup.backend.organization.application;
 
+import feedzupzup.backend.global.annotation.NonTransactionalRead;
 import feedzupzup.backend.global.exception.ResourceException.ResourceNotFoundException;
 import feedzupzup.backend.organization.domain.Organization;
 import feedzupzup.backend.organization.domain.OrganizationRepository;
@@ -13,11 +14,11 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
-@Transactional(readOnly = true)
 public class UserOrganizationService {
 
     private final OrganizationRepository organizationRepository;
 
+    @NonTransactionalRead
     public UserOrganizationResponse getOrganizationByUuid(final UUID organizationUuid) {
         final Organization organization = organizationRepository.findByUuid(organizationUuid)
                 .orElseThrow(() -> new ResourceNotFoundException(

--- a/backend/src/main/java/feedzupzup/backend/qr/service/QRService.java
+++ b/backend/src/main/java/feedzupzup/backend/qr/service/QRService.java
@@ -1,5 +1,6 @@
 package feedzupzup.backend.qr.service;
 
+import feedzupzup.backend.global.annotation.NonTransactionalRead;
 import feedzupzup.backend.global.exception.ResourceException.ResourceExistsException;
 import feedzupzup.backend.global.exception.ResourceException.ResourceNotFoundException;
 import feedzupzup.backend.organization.domain.Organization;
@@ -19,7 +20,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
-@Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class QRService {
 
@@ -31,6 +31,7 @@ public class QRService {
     private final SiteUrl siteUrl;
     private final QRProperties qrProperties;
 
+    @NonTransactionalRead
     public QRResponse getQRCode(final UUID organizationUuid) {
         final Organization organization = getOrganization(organizationUuid);
         final QR qr = getQr(organization);
@@ -62,6 +63,7 @@ public class QRService {
         qrRepository.save(new QR(imageUrl, organization));
     }
 
+    @NonTransactionalRead
     public QRDownloadUrlResponse getDownloadUrl(final UUID organizationUuid) {
         final Organization organization = getOrganization(organizationUuid);
         final QR qr = getQr(organization);


### PR DESCRIPTION
## 🚀 작업 내용
- 성능 향상을 위해 단일 쿼리 조회 시 트랜잭션 삭제
- CQRS의 readOnly 힌트를 주기 위해 @Transation(readOnly = true)를 사용해되, propagation 설정을 통해 트랜잭션 생성 방지하는 커스텀 어노테이션 추가
- SimpleJpaRepository의 기본 @Transaction을 무효화하기 위한 몇몇 메서드 오버라이딩 진행
