### PR TITLE
feat: Custom SSE Metric 추가

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -24,6 +24,7 @@ repositories {
 }
 
 dependencies {
+    implementation platform('io.awspring.cloud:spring-cloud-aws-dependencies:3.4.1')
 
     //develop tool
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
@@ -42,6 +43,7 @@ dependencies {
     implementation 'org.springframework.session:spring-session-jdbc'
 
     //aws
+    implementation 'io.awspring.cloud:spring-cloud-aws-starter'
     implementation 'software.amazon.awssdk:s3:2.30.16'
 
     //QR
@@ -65,7 +67,7 @@ dependencies {
 
     //metric
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
-    implementation 'io.micrometer:micrometer-registry-prometheus'
+    implementation 'io.micrometer:micrometer-registry-cloudwatch2'
 
     //log
     implementation 'net.logstash.logback:logstash-logback-encoder:7.4'

--- a/backend/src/main/java/feedzupzup/backend/feedback/application/UserFeedbackService.java
+++ b/backend/src/main/java/feedzupzup/backend/feedback/application/UserFeedbackService.java
@@ -29,6 +29,7 @@ import feedzupzup.backend.guest.domain.write.WriteHistoryRepository;
 import feedzupzup.backend.guest.dto.GuestInfo;
 import feedzupzup.backend.organization.domain.Organization;
 import feedzupzup.backend.organization.domain.OrganizationRepository;
+import feedzupzup.backend.organization.domain.FeedbackAmount;
 import feedzupzup.backend.organization.domain.OrganizationStatisticRepository;
 import java.util.List;
 import java.util.UUID;
@@ -78,6 +79,8 @@ public class UserFeedbackService {
                 CREATED_WAITING.getConfirmedAmount(),
                 CREATED_WAITING.getWaitingAmount()
         );
+        final FeedbackAmount feedbackAmount = organizationStatisticRepository.findFeedbackAmountByOrganizationId(
+                organization.getId());
 
         // 새로운 피드백이 생성되면 이벤트 발행
         eventPublisher.publishEvent(new FeedbackCreatedEvent(organization.getId(), "피드줍줍"));
@@ -85,7 +88,10 @@ public class UserFeedbackService {
         eventPublisher.publishEvent(new FeedbackCreatedEvent2(savedFeedback.getId()));
 
         // 현재 피드백 개수를, 접속해있는 유저에게 알려주는 이벤트 발행
-        eventPublisher.publishEvent(new OrganizationFeedbackCountEvent(organization.getId()));
+        eventPublisher.publishEvent(OrganizationFeedbackCountEvent.of(
+                organization.getId(),
+                feedbackAmount.getFeedbackTotalCount()
+        ));
 
         return CreateFeedbackResponse.from(savedFeedback);
     }

--- a/backend/src/main/java/feedzupzup/backend/feedback/application/event/OrganizationFeedbackCountHandler.java
+++ b/backend/src/main/java/feedzupzup/backend/feedback/application/event/OrganizationFeedbackCountHandler.java
@@ -1,8 +1,10 @@
 package feedzupzup.backend.feedback.application.event;
 
 import feedzupzup.backend.feedback.event.OrganizationFeedbackCountEvent;
+import feedzupzup.backend.global.message.MessagePublisher;
 import feedzupzup.backend.organization.domain.FeedbackAmount;
 import feedzupzup.backend.organization.domain.OrganizationStatisticRepository;
+import feedzupzup.backend.sse.dto.FeedbackCountMessage;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Async;

--- a/backend/src/main/java/feedzupzup/backend/feedback/application/event/OrganizationFeedbackCountHandler.java
+++ b/backend/src/main/java/feedzupzup/backend/feedback/application/event/OrganizationFeedbackCountHandler.java
@@ -2,8 +2,6 @@ package feedzupzup.backend.feedback.application.event;
 
 import feedzupzup.backend.feedback.event.OrganizationFeedbackCountEvent;
 import feedzupzup.backend.global.message.MessagePublisher;
-import feedzupzup.backend.organization.domain.FeedbackAmount;
-import feedzupzup.backend.organization.domain.OrganizationStatisticRepository;
 import feedzupzup.backend.sse.dto.FeedbackCountMessage;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -19,21 +17,18 @@ public class OrganizationFeedbackCountHandler {
 
     private static final String FEEDBACK_COUNT_TOPIC = "sse:feedback-count";
 
-    private final OrganizationStatisticRepository organizationStatisticRepository;
     private final MessagePublisher messagePublisher;
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     @Async
     public void handleFeedbackCreatedEvent(final OrganizationFeedbackCountEvent organizationFeedbackCountEvent) {
         try {
-            final FeedbackAmount feedbackAmount = organizationStatisticRepository.findFeedbackAmountByOrganizationId(
-                    organizationFeedbackCountEvent.organizationId());
-
             final FeedbackCountMessage message = new FeedbackCountMessage(
                     organizationFeedbackCountEvent.organizationId(),
-                    feedbackAmount.getFeedbackTotalCount()
+                    organizationFeedbackCountEvent.totalFeedbackCount(),
+                    organizationFeedbackCountEvent.eventId(),
+                    organizationFeedbackCountEvent.publishedAt()
             );
-
             messagePublisher.publish(FEEDBACK_COUNT_TOPIC, message);
         } catch (Exception e) {
             log.error("피드백 실시간 알림 비동기 처리 중 예외 발생 - OrganizationId : {}", organizationFeedbackCountEvent.organizationId(), e);

--- a/backend/src/main/java/feedzupzup/backend/feedback/application/event/OrganizationFeedbackCountHandler.java
+++ b/backend/src/main/java/feedzupzup/backend/feedback/application/event/OrganizationFeedbackCountHandler.java
@@ -1,10 +1,8 @@
 package feedzupzup.backend.feedback.application.event;
 
 import feedzupzup.backend.feedback.event.OrganizationFeedbackCountEvent;
-import feedzupzup.backend.global.message.MessagePublisher;
 import feedzupzup.backend.organization.domain.FeedbackAmount;
 import feedzupzup.backend.organization.domain.OrganizationStatisticRepository;
-import feedzupzup.backend.sse.dto.FeedbackCountMessage;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Async;

--- a/backend/src/main/java/feedzupzup/backend/feedback/event/OrganizationFeedbackCountEvent.java
+++ b/backend/src/main/java/feedzupzup/backend/feedback/event/OrganizationFeedbackCountEvent.java
@@ -1,7 +1,23 @@
 package feedzupzup.backend.feedback.event;
 
+import java.util.UUID;
+
 public record OrganizationFeedbackCountEvent(
-        Long organizationId
+        Long organizationId,
+        long totalFeedbackCount,
+        String eventId,
+        long publishedAt
 ) {
 
+    public static OrganizationFeedbackCountEvent of(
+            final Long organizationId,
+            final long totalFeedbackCount
+    ) {
+        return new OrganizationFeedbackCountEvent(
+                organizationId,
+                totalFeedbackCount,
+                UUID.randomUUID().toString(),
+                System.currentTimeMillis()
+        );
+    }
 }

--- a/backend/src/main/java/feedzupzup/backend/global/config/MetricsCommonTagsConfig.java
+++ b/backend/src/main/java/feedzupzup/backend/global/config/MetricsCommonTagsConfig.java
@@ -1,0 +1,18 @@
+package feedzupzup.backend.global.config;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.actuate.autoconfigure.metrics.MeterRegistryCustomizer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class MetricsCommonTagsConfig {
+
+    @Bean
+    MeterRegistryCustomizer<MeterRegistry> metricsCommonTagsCustomizer(
+            @Value("${app.metrics.instance-id:unknown-instance}") final String instanceId
+    ) {
+        return registry -> registry.config().commonTags("InstanceId", instanceId);
+    }
+}

--- a/backend/src/main/java/feedzupzup/backend/global/util/CookieUtilization.java
+++ b/backend/src/main/java/feedzupzup/backend/global/util/CookieUtilization.java
@@ -16,20 +16,17 @@ public class CookieUtilization {
 
     public static final String GUEST_KEY = "guestId";
 
-    private final String cookieDomain;
     private final String sameSite;
     private final long maxAge;
     private final String path;
     private final boolean secure;
 
     public CookieUtilization(
-            @Value("${cookie.domain}") final String cookieDomain,
             @Value("${cookie.sameSite}") final String sameSite,
             @Value("${cookie.max-age}") final long maxAge,
             @Value("${cookie.path}") final String path,
             @Value("${cookie.secure}") final boolean secure
     ) {
-        this.cookieDomain = cookieDomain;
         this.sameSite = sameSite;
         this.maxAge = maxAge;
         this.path = path;
@@ -39,7 +36,6 @@ public class CookieUtilization {
     public ResponseCookie createCookie(String key, UUID value) {
         final ResponseCookie responseCookie = ResponseCookie.from(key, value.toString())
                 .httpOnly(true)
-                .domain(cookieDomain)
                 .sameSite(sameSite)
                 .maxAge(maxAge)
                 .path(path)

--- a/backend/src/main/java/feedzupzup/backend/sse/dto/FeedbackCountMessage.java
+++ b/backend/src/main/java/feedzupzup/backend/sse/dto/FeedbackCountMessage.java
@@ -2,7 +2,8 @@ package feedzupzup.backend.sse.dto;
 
 public record FeedbackCountMessage(
         Long organizationId,
-        long totalFeedbackCount
+        long totalFeedbackCount,
+        String eventId,
+        long publishedAt
 ) {
-
 }

--- a/backend/src/main/java/feedzupzup/backend/sse/event/SseConnectedEvent.java
+++ b/backend/src/main/java/feedzupzup/backend/sse/event/SseConnectedEvent.java
@@ -1,0 +1,8 @@
+package feedzupzup.backend.sse.event;
+
+import feedzupzup.backend.sse.domain.ConnectionType;
+
+public record SseConnectedEvent(
+        ConnectionType connectionType
+) {
+}

--- a/backend/src/main/java/feedzupzup/backend/sse/infrastructure/FileBasedSseTrafficStateAdapter.java
+++ b/backend/src/main/java/feedzupzup/backend/sse/infrastructure/FileBasedSseTrafficStateAdapter.java
@@ -1,0 +1,46 @@
+package feedzupzup.backend.sse.infrastructure;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import feedzupzup.backend.sse.service.SseTrafficStatePort;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+@ConditionalOnProperty("app.deploy-state.path")
+public class FileBasedSseTrafficStateAdapter implements SseTrafficStatePort {
+
+    private final ObjectMapper objectMapper;
+    private final Path stateFilePath;
+
+    public FileBasedSseTrafficStateAdapter(
+            final ObjectMapper objectMapper,
+            @Value("${app.deploy-state.path}") final String stateFilePath
+    ) {
+        this.objectMapper = objectMapper;
+        this.stateFilePath = Path.of(stateFilePath);
+    }
+
+    @Override
+    public boolean shouldNotReceiveSse() {
+        return read().shouldNotReceiveSse();
+    }
+
+    public SseTrafficState read() {
+        if (!Files.exists(stateFilePath)) {
+            return SseTrafficState.allowSse();
+        }
+
+        try {
+            return objectMapper.readValue(stateFilePath.toFile(), SseTrafficState.class);
+        } catch (IOException e) {
+            log.error("배포 상태 파일을 읽지 못해 SSE 허용 상태로 처리합니다. path={}", stateFilePath, e);
+            return SseTrafficState.allowSse();
+        }
+    }
+}

--- a/backend/src/main/java/feedzupzup/backend/sse/infrastructure/FileBasedSseTrafficStateAdapter.java
+++ b/backend/src/main/java/feedzupzup/backend/sse/infrastructure/FileBasedSseTrafficStateAdapter.java
@@ -27,10 +27,6 @@ public class FileBasedSseTrafficStateAdapter implements SseTrafficStatePort {
     }
 
     @Override
-    public boolean shouldNotReceiveSse() {
-        return read().shouldNotReceiveSse();
-    }
-
     public SseTrafficState read() {
         if (!Files.exists(stateFilePath)) {
             return SseTrafficState.allowSse();

--- a/backend/src/main/java/feedzupzup/backend/sse/infrastructure/RedisSseSubscriber.java
+++ b/backend/src/main/java/feedzupzup/backend/sse/infrastructure/RedisSseSubscriber.java
@@ -18,10 +18,7 @@ public class RedisSseSubscriber {
     public void handleMessage(final String message) {
         try {
             final FeedbackCountMessage feedbackCountMessage = objectMapper.readValue(message, FeedbackCountMessage.class);
-            sseService.sendFeedbackNotificationToOrganization(
-                    feedbackCountMessage.organizationId(),
-                    feedbackCountMessage.totalFeedbackCount()
-            );
+            sseService.sendFeedbackNotificationToOrganization(feedbackCountMessage);
         } catch (Exception e) {
             log.error("Redis 메시지 처리 실패 - message: {}", message, e);
         }

--- a/backend/src/main/java/feedzupzup/backend/sse/infrastructure/SseConnectToBlueAfterCutoverMetricsEventListener.java
+++ b/backend/src/main/java/feedzupzup/backend/sse/infrastructure/SseConnectToBlueAfterCutoverMetricsEventListener.java
@@ -1,0 +1,34 @@
+package feedzupzup.backend.sse.infrastructure;
+
+import feedzupzup.backend.sse.event.SseConnectedEvent;
+import feedzupzup.backend.sse.service.SseTrafficStatePort;
+import io.micrometer.core.instrument.MeterRegistry;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class SseConnectToBlueAfterCutoverMetricsEventListener {
+
+    public static final String METRIC_NAME = "sse.connect.to.blue.after.cutover";
+
+    private final MeterRegistry meterRegistry;
+    private final ObjectProvider<SseTrafficStatePort> trafficStatePortProvider;
+
+    @Async
+    @EventListener
+    public void handle(final SseConnectedEvent event) {
+        final SseTrafficStatePort trafficStatePort = trafficStatePortProvider.getIfAvailable();
+        if (trafficStatePort == null || !trafficStatePort.shouldNotReceiveSse()) {
+            return;
+        }
+
+        meterRegistry.counter(
+                METRIC_NAME,
+                "connectionType", event.connectionType().name().toLowerCase()
+        ).increment();
+    }
+}

--- a/backend/src/main/java/feedzupzup/backend/sse/infrastructure/SseMetricsBinder.java
+++ b/backend/src/main/java/feedzupzup/backend/sse/infrastructure/SseMetricsBinder.java
@@ -1,0 +1,27 @@
+package feedzupzup.backend.sse.infrastructure;
+
+import feedzupzup.backend.sse.domain.SseEmitterRepository;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.binder.MeterBinder;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Component;
+
+@Component
+public class SseMetricsBinder implements MeterBinder {
+
+    public static final String ACTIVE_CONNECTIONS_METRIC_NAME = "sse.connections.active";
+
+    private final SseEmitterRepository sseEmitterRepository;
+
+    public SseMetricsBinder(@Qualifier("inMemorySseEmitterRepository") final SseEmitterRepository sseEmitterRepository) {
+        this.sseEmitterRepository = sseEmitterRepository;
+    }
+
+    @Override
+    public void bindTo(final MeterRegistry registry) {
+        Gauge.builder(ACTIVE_CONNECTIONS_METRIC_NAME, sseEmitterRepository, SseEmitterRepository::count)
+                .description("Current number of active SSE connections")
+                .register(registry);
+    }
+}

--- a/backend/src/main/java/feedzupzup/backend/sse/infrastructure/SseMetricsBinder.java
+++ b/backend/src/main/java/feedzupzup/backend/sse/infrastructure/SseMetricsBinder.java
@@ -1,9 +1,11 @@
 package feedzupzup.backend.sse.infrastructure;
 
 import feedzupzup.backend.sse.domain.SseEmitterRepository;
+import feedzupzup.backend.sse.service.SseTrafficStatePort;
 import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.binder.MeterBinder;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
@@ -11,11 +13,18 @@ import org.springframework.stereotype.Component;
 public class SseMetricsBinder implements MeterBinder {
 
     public static final String ACTIVE_CONNECTIONS_METRIC_NAME = "sse.connections.active";
+    public static final String BLUE_ACTIVE_CONNECTIONS_METRIC_NAME = "blue_active_sse_connections";
+    public static final String GREEN_ACTIVE_CONNECTIONS_METRIC_NAME = "green_active_sse_connections";
 
     private final SseEmitterRepository sseEmitterRepository;
+    private final ObjectProvider<SseTrafficStatePort> trafficStatePortProvider;
 
-    public SseMetricsBinder(@Qualifier("inMemorySseEmitterRepository") final SseEmitterRepository sseEmitterRepository) {
+    public SseMetricsBinder(
+            @Qualifier("inMemorySseEmitterRepository") final SseEmitterRepository sseEmitterRepository,
+            final ObjectProvider<SseTrafficStatePort> trafficStatePortProvider
+    ) {
         this.sseEmitterRepository = sseEmitterRepository;
+        this.trafficStatePortProvider = trafficStatePortProvider;
     }
 
     @Override
@@ -23,5 +32,27 @@ public class SseMetricsBinder implements MeterBinder {
         Gauge.builder(ACTIVE_CONNECTIONS_METRIC_NAME, sseEmitterRepository, SseEmitterRepository::count)
                 .description("Current number of active SSE connections")
                 .register(registry);
+
+        Gauge.builder(BLUE_ACTIVE_CONNECTIONS_METRIC_NAME, this, binder -> binder.countConnectionsFor(SseTrafficState.BLUE))
+                .description("Current number of active SSE connections on blue deployment")
+                .register(registry);
+
+        Gauge.builder(GREEN_ACTIVE_CONNECTIONS_METRIC_NAME, this, binder -> binder.countConnectionsFor(SseTrafficState.GREEN))
+                .description("Current number of active SSE connections on green deployment")
+                .register(registry);
+    }
+
+    private int countConnectionsFor(final String deploymentColor) {
+        final SseTrafficStatePort trafficStatePort = trafficStatePortProvider.getIfAvailable();
+        if (trafficStatePort == null) {
+            return 0;
+        }
+
+        final SseTrafficState trafficState = trafficStatePort.read();
+        if (!trafficState.isDeploymentColor(deploymentColor)) {
+            return 0;
+        }
+
+        return sseEmitterRepository.count();
     }
 }

--- a/backend/src/main/java/feedzupzup/backend/sse/infrastructure/SseTrafficState.java
+++ b/backend/src/main/java/feedzupzup/backend/sse/infrastructure/SseTrafficState.java
@@ -1,10 +1,31 @@
 package feedzupzup.backend.sse.infrastructure;
 
 public record SseTrafficState(
+        String deploymentColor,
         boolean shouldNotReceiveSse
 ) {
 
+    public static final String BLUE = "blue";
+    public static final String GREEN = "green";
+    public static final String UNKNOWN = "unknown";
+
+    public SseTrafficState {
+        deploymentColor = normalizeDeploymentColor(deploymentColor);
+    }
+
     public static SseTrafficState allowSse() {
-        return new SseTrafficState(false);
+        return new SseTrafficState(UNKNOWN, false);
+    }
+
+    public boolean isDeploymentColor(final String deploymentColor) {
+        return this.deploymentColor.equals(normalizeDeploymentColor(deploymentColor));
+    }
+
+    private static String normalizeDeploymentColor(final String deploymentColor) {
+        if (deploymentColor == null || deploymentColor.isBlank()) {
+            return UNKNOWN;
+        }
+
+        return deploymentColor.trim().toLowerCase();
     }
 }

--- a/backend/src/main/java/feedzupzup/backend/sse/infrastructure/SseTrafficState.java
+++ b/backend/src/main/java/feedzupzup/backend/sse/infrastructure/SseTrafficState.java
@@ -1,0 +1,10 @@
+package feedzupzup.backend.sse.infrastructure;
+
+public record SseTrafficState(
+        boolean shouldNotReceiveSse
+) {
+
+    public static SseTrafficState allowSse() {
+        return new SseTrafficState(false);
+    }
+}

--- a/backend/src/main/java/feedzupzup/backend/sse/service/SseService.java
+++ b/backend/src/main/java/feedzupzup/backend/sse/service/SseService.java
@@ -5,6 +5,7 @@ import feedzupzup.backend.organization.domain.Organization;
 import feedzupzup.backend.organization.domain.OrganizationRepository;
 import feedzupzup.backend.sse.domain.ConnectionType;
 import feedzupzup.backend.sse.domain.SseEmitterRepository;
+import feedzupzup.backend.sse.dto.FeedbackCountMessage;
 import feedzupzup.backend.sse.event.SseConnectedEvent;
 import java.io.IOException;
 import java.util.Map;
@@ -76,7 +77,8 @@ public class SseService {
         return emitter;
     }
 
-    public void sendFeedbackNotificationToOrganization(final Long organizationId, final long totalFeedbackCount) {
+    public void sendFeedbackNotificationToOrganization(final FeedbackCountMessage feedbackCountMessage) {
+        final Long organizationId = feedbackCountMessage.organizationId();
         final Map<String, SseEmitter> sseEmitters = sseEmitterRepository.findAllByOrganizationId(
                 organizationId);
         log.info("피드백 수 전송 시작 - Organization: {}", organizationId);
@@ -96,8 +98,9 @@ public class SseService {
 
             try {
                 emitter.send(SseEmitter.event()
+                        .id(feedbackCountMessage.eventId())
                         .name("feedback-total-count-notification")
-                        .data(totalFeedbackCount));
+                        .data(feedbackCountMessage));
                 successCount ++;
             } catch (IOException e) {
                 log.warn("피드백 수 전송 실패 - Emitter: {}, 원인: {}", emitterId, e.getMessage());

--- a/backend/src/main/java/feedzupzup/backend/sse/service/SseService.java
+++ b/backend/src/main/java/feedzupzup/backend/sse/service/SseService.java
@@ -5,11 +5,13 @@ import feedzupzup.backend.organization.domain.Organization;
 import feedzupzup.backend.organization.domain.OrganizationRepository;
 import feedzupzup.backend.sse.domain.ConnectionType;
 import feedzupzup.backend.sse.domain.SseEmitterRepository;
+import feedzupzup.backend.sse.event.SseConnectedEvent;
 import java.io.IOException;
 import java.util.Map;
 import java.util.UUID;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.event.ContextClosedEvent;
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Service;
@@ -21,14 +23,17 @@ public class SseService {
 
     private final SseEmitterRepository sseEmitterRepository;
     private final OrganizationRepository organizationRepository;
+    private final ApplicationEventPublisher eventPublisher;
 
     public SseService(
             @Qualifier("inMemorySseEmitterRepository")
             final SseEmitterRepository sseEmitterRepository,
-            final OrganizationRepository organizationRepository
+            final OrganizationRepository organizationRepository,
+            final ApplicationEventPublisher eventPublisher
     ) {
         this.sseEmitterRepository = sseEmitterRepository;
         this.organizationRepository = organizationRepository;
+        this.eventPublisher = eventPublisher;
     }
 
     public SseEmitter createEmitter(
@@ -44,6 +49,7 @@ public class SseService {
 
         sseEmitterRepository.save(emitterId, emitter);
         log.info("SSE 연결 생성 - Type: {}, Emitter ID: {}", connectionType, emitterId);
+        eventPublisher.publishEvent(new SseConnectedEvent(connectionType));
 
         emitter.onCompletion(() -> {
             log.info("SSE 연결 정상 종료 - {}", emitterId);

--- a/backend/src/main/java/feedzupzup/backend/sse/service/SseTrafficStatePort.java
+++ b/backend/src/main/java/feedzupzup/backend/sse/service/SseTrafficStatePort.java
@@ -1,0 +1,6 @@
+package feedzupzup.backend.sse.service;
+
+public interface SseTrafficStatePort {
+
+    boolean shouldNotReceiveSse();
+}

--- a/backend/src/main/java/feedzupzup/backend/sse/service/SseTrafficStatePort.java
+++ b/backend/src/main/java/feedzupzup/backend/sse/service/SseTrafficStatePort.java
@@ -1,6 +1,12 @@
 package feedzupzup.backend.sse.service;
 
+import feedzupzup.backend.sse.infrastructure.SseTrafficState;
+
 public interface SseTrafficStatePort {
 
-    boolean shouldNotReceiveSse();
+    SseTrafficState read();
+
+    default boolean shouldNotReceiveSse() {
+        return read().shouldNotReceiveSse();
+    }
 }

--- a/backend/src/test/java/feedzupzup/backend/feedback/application/event/OrganizationFeedbackCountHandlerTest.java
+++ b/backend/src/test/java/feedzupzup/backend/feedback/application/event/OrganizationFeedbackCountHandlerTest.java
@@ -1,7 +1,9 @@
 package feedzupzup.backend.feedback.application.event;
 
 import static feedzupzup.backend.category.domain.Category.SUGGESTION;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.argThat;
 import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
 
@@ -11,6 +13,7 @@ import feedzupzup.backend.category.fixture.OrganizationCategoryFixture;
 import feedzupzup.backend.config.ServiceIntegrationHelper;
 import feedzupzup.backend.feedback.application.UserFeedbackService;
 import feedzupzup.backend.feedback.dto.request.CreateFeedbackRequest;
+import feedzupzup.backend.global.message.MessagePublisher;
 import feedzupzup.backend.global.util.CurrentDateTime;
 import feedzupzup.backend.guest.domain.guest.Guest;
 import feedzupzup.backend.guest.domain.guest.GuestRepository;
@@ -20,7 +23,7 @@ import feedzupzup.backend.organization.domain.OrganizationRepository;
 import feedzupzup.backend.organization.domain.OrganizationStatistic;
 import feedzupzup.backend.organization.domain.OrganizationStatisticRepository;
 import feedzupzup.backend.organization.fixture.OrganizationFixture;
-import feedzupzup.backend.sse.service.SseService;
+import feedzupzup.backend.sse.dto.FeedbackCountMessage;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -46,7 +49,7 @@ class OrganizationFeedbackCountHandlerTest extends ServiceIntegrationHelper {
     private GuestRepository guestRepository;
 
     @MockitoBean
-    private SseService sseService;
+    private MessagePublisher messagePublisher;
 
     private Organization organization;
     private OrganizationCategory organizationCategory;
@@ -85,10 +88,10 @@ class OrganizationFeedbackCountHandlerTest extends ServiceIntegrationHelper {
         userFeedbackService.create(request, organization.getUuid(), guestInfo);
 
         // then - SSE 알림이 발송되었는지 검증 (비동기 처리를 위해 timeout 사용)
-        verify(sseService, timeout(2000).times(1))
-                .sendFeedbackNotificationToOrganization(
-                        eq(organization.getId()),
-                        eq(1L)
+        verify(messagePublisher, timeout(2000).times(1))
+                .publish(
+                        eq("sse:feedback-count"),
+                        argThat(argument -> hasExpectedFeedbackCountMessage(argument, 1L))
                 );
     }
 
@@ -98,30 +101,29 @@ class OrganizationFeedbackCountHandlerTest extends ServiceIntegrationHelper {
         // given
         final GuestInfo guestInfo = new GuestInfo(guest.getGuestUuid());
 
-        // when - 3개의 피드백 생성
         userFeedbackService.create(
                 new CreateFeedbackRequest("피드백 1", false, "작성자1", SUGGESTION.getKoreanName(), null),
                 organization.getUuid(),
                 guestInfo
         );
+        verify(messagePublisher, timeout(2000).times(1))
+                .publish(eq("sse:feedback-count"), argThat(argument -> hasExpectedFeedbackCountMessage(argument, 1L)));
+
         userFeedbackService.create(
                 new CreateFeedbackRequest("피드백 2", false, "작성자2", SUGGESTION.getKoreanName(), null),
                 organization.getUuid(),
                 guestInfo
         );
+        verify(messagePublisher, timeout(2000).times(1))
+                .publish(eq("sse:feedback-count"), argThat(argument -> hasExpectedFeedbackCountMessage(argument, 2L)));
+
         userFeedbackService.create(
                 new CreateFeedbackRequest("피드백 3", false, "작성자3", SUGGESTION.getKoreanName(), null),
                 organization.getUuid(),
                 guestInfo
         );
-
-        // then - 각 피드백 생성마다 SSE 알림이 발송되었는지 검증
-        verify(sseService, timeout(2000).times(1))
-                .sendFeedbackNotificationToOrganization(eq(organization.getId()), eq(1L));
-        verify(sseService, timeout(2000).times(1))
-                .sendFeedbackNotificationToOrganization(eq(organization.getId()), eq(2L));
-        verify(sseService, timeout(2000).times(1))
-                .sendFeedbackNotificationToOrganization(eq(organization.getId()), eq(3L));
+        verify(messagePublisher, timeout(2000).times(1))
+                .publish(eq("sse:feedback-count"), argThat(argument -> hasExpectedFeedbackCountMessage(argument, 3L)));
     }
 
     @Test
@@ -141,10 +143,21 @@ class OrganizationFeedbackCountHandlerTest extends ServiceIntegrationHelper {
         userFeedbackService.create(request, organization.getUuid(), guestInfo);
 
         // then - 정확한 organizationUuid와 totalCount로 SSE 알림이 발송되었는지 검증
-        verify(sseService, timeout(2000).times(1))
-                .sendFeedbackNotificationToOrganization(
-                        eq(organization.getId()),
-                        eq(1L)
+        verify(messagePublisher, timeout(2000).times(1))
+                .publish(
+                        eq("sse:feedback-count"),
+                        argThat(argument -> hasExpectedFeedbackCountMessage(argument, 1L))
                 );
+    }
+
+    private boolean hasExpectedFeedbackCountMessage(final Object argument, final long expectedFeedbackCount) {
+        assertThat(argument).isInstanceOf(FeedbackCountMessage.class);
+
+        final FeedbackCountMessage message = (FeedbackCountMessage) argument;
+        assertThat(message.organizationId()).isEqualTo(organization.getId());
+        assertThat(message.totalFeedbackCount()).isEqualTo(expectedFeedbackCount);
+        assertThat(message.eventId()).isNotBlank();
+        assertThat(message.publishedAt()).isPositive();
+        return true;
     }
 }

--- a/backend/src/test/java/feedzupzup/backend/sse/infrastructure/FileBasedSseTrafficStateAdapterTest.java
+++ b/backend/src/test/java/feedzupzup/backend/sse/infrastructure/FileBasedSseTrafficStateAdapterTest.java
@@ -26,15 +26,17 @@ class FileBasedSseTrafficStateAdapterTest {
                 missingFilePath.toString()
         );
 
+        assertThat(stateReader.read().deploymentColor()).isEqualTo(SseTrafficState.UNKNOWN);
         assertThat(stateReader.shouldNotReceiveSse()).isFalse();
     }
 
     @Test
-    @DisplayName("상태 파일의 shouldNotReceiveSse 값을 읽는다")
+    @DisplayName("상태 파일의 배포 색상과 shouldNotReceiveSse 값을 읽는다")
     void readShouldNotReceiveSseFromStateFile() throws IOException {
         final Path stateFilePath = tempDir.resolve("deploy-state.json");
         Files.writeString(stateFilePath, """
                 {
+                  "deploymentColor": "blue",
                   "shouldNotReceiveSse": true
                 }
                 """);
@@ -43,7 +45,9 @@ class FileBasedSseTrafficStateAdapterTest {
                 stateFilePath.toString()
         );
 
-        assertThat(stateReader.shouldNotReceiveSse()).isTrue();
+        final SseTrafficState trafficState = stateReader.read();
+        assertThat(trafficState.deploymentColor()).isEqualTo(SseTrafficState.BLUE);
+        assertThat(trafficState.shouldNotReceiveSse()).isTrue();
     }
 
     @Test
@@ -56,6 +60,7 @@ class FileBasedSseTrafficStateAdapterTest {
                 stateFilePath.toString()
         );
 
+        assertThat(stateReader.read().deploymentColor()).isEqualTo(SseTrafficState.UNKNOWN);
         assertThat(stateReader.shouldNotReceiveSse()).isFalse();
     }
 }

--- a/backend/src/test/java/feedzupzup/backend/sse/infrastructure/FileBasedSseTrafficStateAdapterTest.java
+++ b/backend/src/test/java/feedzupzup/backend/sse/infrastructure/FileBasedSseTrafficStateAdapterTest.java
@@ -1,0 +1,61 @@
+package feedzupzup.backend.sse.infrastructure;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class FileBasedSseTrafficStateAdapterTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    @DisplayName("상태 파일이 없으면 SSE를 허용한다")
+    void allowSseWhenStateFileDoesNotExist() {
+        final Path missingFilePath = tempDir.resolve("missing-deploy-state.json");
+        final FileBasedSseTrafficStateAdapter stateReader = new FileBasedSseTrafficStateAdapter(
+                objectMapper,
+                missingFilePath.toString()
+        );
+
+        assertThat(stateReader.shouldNotReceiveSse()).isFalse();
+    }
+
+    @Test
+    @DisplayName("상태 파일의 shouldNotReceiveSse 값을 읽는다")
+    void readShouldNotReceiveSseFromStateFile() throws IOException {
+        final Path stateFilePath = tempDir.resolve("deploy-state.json");
+        Files.writeString(stateFilePath, """
+                {
+                  "shouldNotReceiveSse": true
+                }
+                """);
+        final FileBasedSseTrafficStateAdapter stateReader = new FileBasedSseTrafficStateAdapter(
+                objectMapper,
+                stateFilePath.toString()
+        );
+
+        assertThat(stateReader.shouldNotReceiveSse()).isTrue();
+    }
+
+    @Test
+    @DisplayName("상태 파일이 깨져 있으면 SSE를 허용한다")
+    void allowSseWhenStateFileIsInvalid() throws IOException {
+        final Path stateFilePath = tempDir.resolve("deploy-state.json");
+        Files.writeString(stateFilePath, "{ invalid json }");
+        final FileBasedSseTrafficStateAdapter stateReader = new FileBasedSseTrafficStateAdapter(
+                objectMapper,
+                stateFilePath.toString()
+        );
+
+        assertThat(stateReader.shouldNotReceiveSse()).isFalse();
+    }
+}

--- a/backend/src/test/java/feedzupzup/backend/sse/infrastructure/RedisSseSubscriberTest.java
+++ b/backend/src/test/java/feedzupzup/backend/sse/infrastructure/RedisSseSubscriberTest.java
@@ -1,0 +1,33 @@
+package feedzupzup.backend.sse.infrastructure;
+
+import static org.mockito.Mockito.verify;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import feedzupzup.backend.sse.dto.FeedbackCountMessage;
+import feedzupzup.backend.sse.service.SseService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+class RedisSseSubscriberTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final SseService sseService = Mockito.mock(SseService.class);
+
+    @Test
+    @DisplayName("Redis 메시지를 받으면 SSE 서비스로 피드백 수 알림을 전달한다")
+    void handleMessage() throws Exception {
+        final RedisSseSubscriber subscriber = new RedisSseSubscriber(objectMapper, sseService);
+        final FeedbackCountMessage feedbackCountMessage = new FeedbackCountMessage(
+                1L,
+                3L,
+                "event-1",
+                1_742_545_678_901L
+        );
+        final String message = objectMapper.writeValueAsString(feedbackCountMessage);
+
+        subscriber.handleMessage(message);
+
+        verify(sseService).sendFeedbackNotificationToOrganization(feedbackCountMessage);
+    }
+}

--- a/backend/src/test/java/feedzupzup/backend/sse/infrastructure/SseMetricsBinderTest.java
+++ b/backend/src/test/java/feedzupzup/backend/sse/infrastructure/SseMetricsBinderTest.java
@@ -6,6 +6,7 @@ import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 class SseMetricsBinderTest {
@@ -19,7 +20,10 @@ class SseMetricsBinderTest {
         sseEmitterRepository.save("1_ADMIN_user-b_1001", new SseEmitter());
 
         final SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
-        final SseMetricsBinder sseMetricsBinder = new SseMetricsBinder(sseEmitterRepository);
+        final SseMetricsBinder sseMetricsBinder = new SseMetricsBinder(
+                sseEmitterRepository,
+                objectProvider(null)
+        );
 
         // when
         sseMetricsBinder.bindTo(meterRegistry);
@@ -28,5 +32,74 @@ class SseMetricsBinderTest {
         final Gauge gauge = meterRegistry.get(SseMetricsBinder.ACTIVE_CONNECTIONS_METRIC_NAME).gauge();
         assertThat(gauge).isNotNull();
         assertThat(gauge.value()).isEqualTo(2.0);
+    }
+
+    @Test
+    @DisplayName("blue 배포 인스턴스면 blue 메트릭에만 활성 SSE 연결 수를 노출한다")
+    void bindBlueActiveConnectionsGauge() {
+        final InMemorySseEmitterRepository sseEmitterRepository = new InMemorySseEmitterRepository();
+        sseEmitterRepository.save("1_GUEST_user-a_1000", new SseEmitter());
+        sseEmitterRepository.save("1_ADMIN_user-b_1001", new SseEmitter());
+
+        final SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
+        final SseMetricsBinder sseMetricsBinder = new SseMetricsBinder(
+                sseEmitterRepository,
+                objectProvider(() -> new SseTrafficState(SseTrafficState.BLUE, false))
+        );
+
+        sseMetricsBinder.bindTo(meterRegistry);
+
+        final Gauge blueGauge = meterRegistry.get(SseMetricsBinder.BLUE_ACTIVE_CONNECTIONS_METRIC_NAME).gauge();
+        final Gauge greenGauge = meterRegistry.get(SseMetricsBinder.GREEN_ACTIVE_CONNECTIONS_METRIC_NAME).gauge();
+
+        assertThat(blueGauge.value()).isEqualTo(2.0);
+        assertThat(greenGauge.value()).isZero();
+    }
+
+    @Test
+    @DisplayName("green 배포 인스턴스면 green 메트릭에만 활성 SSE 연결 수를 노출한다")
+    void bindGreenActiveConnectionsGauge() {
+        final InMemorySseEmitterRepository sseEmitterRepository = new InMemorySseEmitterRepository();
+        sseEmitterRepository.save("1_GUEST_user-a_1000", new SseEmitter());
+
+        final SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
+        final SseMetricsBinder sseMetricsBinder = new SseMetricsBinder(
+                sseEmitterRepository,
+                objectProvider(() -> new SseTrafficState(SseTrafficState.GREEN, false))
+        );
+
+        sseMetricsBinder.bindTo(meterRegistry);
+
+        final Gauge blueGauge = meterRegistry.get(SseMetricsBinder.BLUE_ACTIVE_CONNECTIONS_METRIC_NAME).gauge();
+        final Gauge greenGauge = meterRegistry.get(SseMetricsBinder.GREEN_ACTIVE_CONNECTIONS_METRIC_NAME).gauge();
+
+        assertThat(blueGauge.value()).isZero();
+        assertThat(greenGauge.value()).isEqualTo(1.0);
+    }
+
+    private static ObjectProvider<feedzupzup.backend.sse.service.SseTrafficStatePort> objectProvider(
+            final feedzupzup.backend.sse.service.SseTrafficStatePort trafficStatePort
+    ) {
+        return new ObjectProvider<>() {
+            @Override
+            public feedzupzup.backend.sse.service.SseTrafficStatePort getObject(final Object... args) {
+                return trafficStatePort;
+            }
+
+            @Override
+            public feedzupzup.backend.sse.service.SseTrafficStatePort getIfAvailable() {
+                return trafficStatePort;
+            }
+
+            @Override
+            public feedzupzup.backend.sse.service.SseTrafficStatePort getIfUnique() {
+                return trafficStatePort;
+            }
+
+            @Override
+            public feedzupzup.backend.sse.service.SseTrafficStatePort getObject() {
+                return trafficStatePort;
+            }
+        };
     }
 }

--- a/backend/src/test/java/feedzupzup/backend/sse/infrastructure/SseMetricsBinderTest.java
+++ b/backend/src/test/java/feedzupzup/backend/sse/infrastructure/SseMetricsBinderTest.java
@@ -1,0 +1,32 @@
+package feedzupzup.backend.sse.infrastructure;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+class SseMetricsBinderTest {
+
+    @Test
+    @DisplayName("현재 활성 SSE 연결 수를 Gauge 메트릭으로 노출한다")
+    void bindActiveConnectionsGauge() {
+        // given
+        final InMemorySseEmitterRepository sseEmitterRepository = new InMemorySseEmitterRepository();
+        sseEmitterRepository.save("1_GUEST_user-a_1000", new SseEmitter());
+        sseEmitterRepository.save("1_ADMIN_user-b_1001", new SseEmitter());
+
+        final SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
+        final SseMetricsBinder sseMetricsBinder = new SseMetricsBinder(sseEmitterRepository);
+
+        // when
+        sseMetricsBinder.bindTo(meterRegistry);
+
+        // then
+        final Gauge gauge = meterRegistry.get(SseMetricsBinder.ACTIVE_CONNECTIONS_METRIC_NAME).gauge();
+        assertThat(gauge).isNotNull();
+        assertThat(gauge.value()).isEqualTo(2.0);
+    }
+}


### PR DESCRIPTION
## 😉 연관 이슈
#6 

## 🚀 작업 내용
- SSE 연결 상태를 확인할 수 있는 Custom Metric을 추가 (SSE_CONNECTION_COUNT)
- Custom Metric을 관리하기 위해 Cloudwatch Registry 도입
- 사용하지 않는 Prometheus 의존성 제거

## 💬 리뷰 중점사항
