### PR TITLE
refactor: SSE 재연결 이슈로 인한 flag 추가

### DIFF
--- a/backend/src/main/java/feedzupzup/backend/auth/presentation/filter/InternalFilter.java
+++ b/backend/src/main/java/feedzupzup/backend/auth/presentation/filter/InternalFilter.java
@@ -1,0 +1,33 @@
+package feedzupzup.backend.auth.presentation.filter;
+
+import java.io.IOException;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Component
+public class InternalFilter extends OncePerRequestFilter {
+
+    private static final String INTERNAL_PATH_PREFIX = "/internal/";
+    private static final String LOCALHOST_IPV4 = "127.0.0.1";
+    private static final String LOCALHOST_IPV6 = "0:0:0:0:0:0:0:1";
+
+    @Override
+    protected void doFilterInternal(final HttpServletRequest request, final HttpServletResponse response, final FilterChain filterChain)
+            throws ServletException, IOException {
+        if (request.getRequestURI().startsWith(INTERNAL_PATH_PREFIX) && !isLocalhost(request)) {
+            response.sendError(HttpServletResponse.SC_FORBIDDEN);
+            return;
+        }
+        filterChain.doFilter(request, response);
+    }
+
+    private boolean isLocalhost(final HttpServletRequest request) {
+        final String remoteAddr = request.getRemoteAddr();
+        return LOCALHOST_IPV4.equals(remoteAddr) || LOCALHOST_IPV6.equals(remoteAddr);
+    }
+}

--- a/backend/src/main/java/feedzupzup/backend/auth/presentation/filter/InternalFilter.java
+++ b/backend/src/main/java/feedzupzup/backend/auth/presentation/filter/InternalFilter.java
@@ -6,6 +6,7 @@ import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
@@ -13,21 +14,20 @@ import org.springframework.web.filter.OncePerRequestFilter;
 public class InternalFilter extends OncePerRequestFilter {
 
     private static final String INTERNAL_PATH_PREFIX = "/internal/";
-    private static final String LOCALHOST_IPV4 = "127.0.0.1";
-    private static final String LOCALHOST_IPV6 = "0:0:0:0:0:0:0:1";
+
+    @Value("${internal.secret-key}")
+    private String secretKey;
 
     @Override
     protected void doFilterInternal(final HttpServletRequest request, final HttpServletResponse response, final FilterChain filterChain)
             throws ServletException, IOException {
-        if (request.getRequestURI().startsWith(INTERNAL_PATH_PREFIX) && !isLocalhost(request)) {
-            response.sendError(HttpServletResponse.SC_FORBIDDEN);
-            return;
+        if (request.getRequestURI().startsWith(INTERNAL_PATH_PREFIX)) {
+            final String requestKey = request.getHeader("X-Internal-Key");
+            if (!secretKey.equals(requestKey)) {
+                response.sendError(HttpServletResponse.SC_FORBIDDEN);
+                return;
+            }
         }
         filterChain.doFilter(request, response);
-    }
-
-    private boolean isLocalhost(final HttpServletRequest request) {
-        final String remoteAddr = request.getRemoteAddr();
-        return LOCALHOST_IPV4.equals(remoteAddr) || LOCALHOST_IPV6.equals(remoteAddr);
     }
 }

--- a/backend/src/main/java/feedzupzup/backend/global/response/ErrorCode.java
+++ b/backend/src/main/java/feedzupzup/backend/global/response/ErrorCode.java
@@ -4,6 +4,7 @@ import static org.springframework.http.HttpStatus.BAD_REQUEST;
 import static org.springframework.http.HttpStatus.FORBIDDEN;
 import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
 import static org.springframework.http.HttpStatus.NOT_FOUND;
+import static org.springframework.http.HttpStatus.SERVICE_UNAVAILABLE;
 import static org.springframework.http.HttpStatus.UNAUTHORIZED;
 
 import lombok.Getter;
@@ -68,6 +69,9 @@ public enum ErrorCode {
     S3_UPLOAD_FAILED(INTERNAL_SERVER_ERROR, "S01", "파일 업로드에 실패하였습니다."),
     S3_PRESIGNED_FAILED(INTERNAL_SERVER_ERROR, "S02", "Presigned URL 생성에 실패하였습니다."),
     S3_DOWNLOAD_FAILED(INTERNAL_SERVER_ERROR, "S03", "파일 다운로드에 실패하였습니다."),
+
+    //SSE Error
+    SSE_CONNECTION_REFUSED(SERVICE_UNAVAILABLE, "SSE01", "현재 SSE 연결을 받을 수 없습니다."),
 
     //Poi Excel Error
     POI_EXCEL_EXPORT_FAIL(INTERNAL_SERVER_ERROR, "E01", "엑셀 파일 생성에 실패하였습니다.");

--- a/backend/src/main/java/feedzupzup/backend/internal/controller/InternalController.java
+++ b/backend/src/main/java/feedzupzup/backend/internal/controller/InternalController.java
@@ -3,7 +3,7 @@ package feedzupzup.backend.internal.controller;
 import feedzupzup.backend.sse.service.SseService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -12,9 +12,15 @@ public class InternalController {
 
     private final SseService sseService;
 
-    @GetMapping("/internal/sse/disconnect")
+    @PostMapping("/internal/sse/disconnect")
     public ResponseEntity<Void> disconnectAllSse() {
         sseService.completeAllEmitters();
+        return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/internal/sse/resume")
+    public ResponseEntity<Void> resumeSse() {
+        sseService.resumeAccepting();
         return ResponseEntity.ok().build();
     }
 

--- a/backend/src/main/java/feedzupzup/backend/internal/controller/InternalController.java
+++ b/backend/src/main/java/feedzupzup/backend/internal/controller/InternalController.java
@@ -1,0 +1,21 @@
+package feedzupzup.backend.internal.controller;
+
+import feedzupzup.backend.sse.service.SseService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class InternalController {
+
+    private final SseService sseService;
+
+    @GetMapping("/internal/sse/disconnect")
+    public ResponseEntity<Void> disconnectAllSse() {
+        sseService.completeAllEmitters();
+        return ResponseEntity.ok().build();
+    }
+
+}

--- a/backend/src/main/java/feedzupzup/backend/sse/domain/SseAcceptingStatus.java
+++ b/backend/src/main/java/feedzupzup/backend/sse/domain/SseAcceptingStatus.java
@@ -1,0 +1,23 @@
+package feedzupzup.backend.sse.domain;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.springframework.stereotype.Component;
+
+@Component
+public class SseAcceptingStatus {
+
+    private final AtomicBoolean accepting = new AtomicBoolean(true);
+
+    public void stopAccepting() {
+        accepting.set(false);
+    }
+
+    public void resumeAccepting() {
+        accepting.set(true);
+    }
+
+    public boolean isAcceptStatus() {
+        return accepting.get();
+    }
+
+}

--- a/backend/src/main/java/feedzupzup/backend/sse/exception/SseException.java
+++ b/backend/src/main/java/feedzupzup/backend/sse/exception/SseException.java
@@ -1,0 +1,20 @@
+package feedzupzup.backend.sse.exception;
+
+import feedzupzup.backend.global.exception.DomainException;
+import feedzupzup.backend.global.response.ErrorCode;
+
+public class SseException extends DomainException {
+
+    public SseException(final ErrorCode errorCode, final String message) {
+        super(errorCode, message);
+    }
+
+    public static final class SseConnectionRefusedException extends SseException {
+
+        private static final ErrorCode errorCode = ErrorCode.SSE_CONNECTION_REFUSED;
+
+        public SseConnectionRefusedException(String message) {
+            super(errorCode, message);
+        }
+    }
+}

--- a/backend/src/main/java/feedzupzup/backend/sse/service/SseService.java
+++ b/backend/src/main/java/feedzupzup/backend/sse/service/SseService.java
@@ -4,9 +4,11 @@ import feedzupzup.backend.global.exception.ResourceException.ResourceNotFoundExc
 import feedzupzup.backend.organization.domain.Organization;
 import feedzupzup.backend.organization.domain.OrganizationRepository;
 import feedzupzup.backend.sse.domain.ConnectionType;
+import feedzupzup.backend.sse.domain.SseAcceptingStatus;
 import feedzupzup.backend.sse.domain.SseEmitterRepository;
 import feedzupzup.backend.sse.dto.FeedbackCountMessage;
 import feedzupzup.backend.sse.event.SseConnectedEvent;
+import feedzupzup.backend.sse.exception.SseException.SseConnectionRefusedException;
 import java.io.IOException;
 import java.util.Map;
 import java.util.UUID;
@@ -25,16 +27,19 @@ public class SseService {
     private final SseEmitterRepository sseEmitterRepository;
     private final OrganizationRepository organizationRepository;
     private final ApplicationEventPublisher eventPublisher;
+    private final SseAcceptingStatus sseAcceptingStatus;
 
     public SseService(
             @Qualifier("inMemorySseEmitterRepository")
             final SseEmitterRepository sseEmitterRepository,
             final OrganizationRepository organizationRepository,
-            final ApplicationEventPublisher eventPublisher
+            final ApplicationEventPublisher eventPublisher,
+            final SseAcceptingStatus sseAcceptingStatus
     ) {
         this.sseEmitterRepository = sseEmitterRepository;
         this.organizationRepository = organizationRepository;
         this.eventPublisher = eventPublisher;
+        this.sseAcceptingStatus = sseAcceptingStatus;
     }
 
     public SseEmitter createEmitter(
@@ -42,6 +47,9 @@ public class SseService {
             final String userId,
             final ConnectionType connectionType
     ) {
+        if (!sseAcceptingStatus.isAcceptStatus()) {
+            throw new SseConnectionRefusedException("현재 SSE 연결을 받을 수 없는 상태입니다.");
+        }
         final SseEmitter emitter = new SseEmitter(Long.MAX_VALUE);
         final Organization organization = organizationRepository.findByUuid(organizationUuid)
                 .orElseThrow(() -> new ResourceNotFoundException("존재하지 않는 조직 UUID 입니다."));
@@ -112,8 +120,13 @@ public class SseService {
                 organizationId, successCount, failCount);
     }
 
+    public void resumeAccepting() {
+        sseAcceptingStatus.resumeAccepting();
+    }
+
     @EventListener(ContextClosedEvent.class)
     public void completeAllEmitters() {
+        sseAcceptingStatus.stopAccepting();
         final Map<String, SseEmitter> allEmitters = sseEmitterRepository.findAll();
         log.info("SSE 연결 전체 해제 시작 - {} 개", allEmitters.size());
 

--- a/backend/src/test/java/feedzupzup/backend/auth/presentation/filter/InternalFilterTest.java
+++ b/backend/src/test/java/feedzupzup/backend/auth/presentation/filter/InternalFilterTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.verify;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -15,9 +16,12 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 
 @ExtendWith(MockitoExtension.class)
 class InternalFilterTest {
+
+    private static final String SECRET_KEY = "test-internal-secret-key";
 
     @Mock
     private HttpServletRequest request;
@@ -31,12 +35,17 @@ class InternalFilterTest {
     @InjectMocks
     private InternalFilter internalFilter;
 
+    @BeforeEach
+    void setUp() {
+        ReflectionTestUtils.setField(internalFilter, "secretKey", SECRET_KEY);
+    }
+
     @Test
-    @DisplayName("localhost(IPv4)에서 internal API 요청 시 필터를 통과한다")
-    void localhost_ipv4_passes() throws Exception {
+    @DisplayName("올바른 internal key로 internal API 요청 시 필터를 통과한다")
+    void valid_internal_key_passes() throws Exception {
         // Given
         given(request.getRequestURI()).willReturn("/internal/sse/disconnect");
-        given(request.getRemoteAddr()).willReturn("127.0.0.1");
+        given(request.getHeader("X-Internal-Key")).willReturn(SECRET_KEY);
 
         // When
         internalFilter.doFilterInternal(request, response, filterChain);
@@ -46,25 +55,11 @@ class InternalFilterTest {
     }
 
     @Test
-    @DisplayName("localhost(IPv6)에서 internal API 요청 시 필터를 통과한다")
-    void localhost_ipv6_passes() throws Exception {
+    @DisplayName("internal key가 없으면 403을 반환한다")
+    void missing_internal_key_returns_403() throws Exception {
         // Given
         given(request.getRequestURI()).willReturn("/internal/sse/disconnect");
-        given(request.getRemoteAddr()).willReturn("0:0:0:0:0:0:0:1");
-
-        // When
-        internalFilter.doFilterInternal(request, response, filterChain);
-
-        // Then
-        verify(filterChain).doFilter(request, response);
-    }
-
-    @Test
-    @DisplayName("외부 IP에서 internal API 요청 시 403을 반환한다")
-    void external_ip_returns_403() throws Exception {
-        // Given
-        given(request.getRequestURI()).willReturn("/internal/sse/disconnect");
-        given(request.getRemoteAddr()).willReturn("192.168.1.100");
+        given(request.getHeader("X-Internal-Key")).willReturn(null);
 
         // When
         internalFilter.doFilterInternal(request, response, filterChain);
@@ -77,7 +72,24 @@ class InternalFilterTest {
     }
 
     @Test
-    @DisplayName("internal 경로가 아닌 요청은 IP에 관계없이 필터를 통과한다")
+    @DisplayName("잘못된 internal key로 요청하면 403을 반환한다")
+    void invalid_internal_key_returns_403() throws Exception {
+        // Given
+        given(request.getRequestURI()).willReturn("/internal/sse/disconnect");
+        given(request.getHeader("X-Internal-Key")).willReturn("wrong-key");
+
+        // When
+        internalFilter.doFilterInternal(request, response, filterChain);
+
+        // Then
+        ArgumentCaptor<Integer> statusCaptor = ArgumentCaptor.forClass(Integer.class);
+        verify(response).sendError(statusCaptor.capture());
+        assertThat(statusCaptor.getValue()).isEqualTo(403);
+        verify(filterChain, never()).doFilter(request, response);
+    }
+
+    @Test
+    @DisplayName("internal 경로가 아닌 요청은 헤더와 관계없이 필터를 통과한다")
     void non_internal_path_passes() throws Exception {
         // Given
         given(request.getRequestURI()).willReturn("/admin/organizations");

--- a/backend/src/test/java/feedzupzup/backend/auth/presentation/filter/InternalFilterTest.java
+++ b/backend/src/test/java/feedzupzup/backend/auth/presentation/filter/InternalFilterTest.java
@@ -1,0 +1,91 @@
+package feedzupzup.backend.auth.presentation.filter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class InternalFilterTest {
+
+    @Mock
+    private HttpServletRequest request;
+
+    @Mock
+    private HttpServletResponse response;
+
+    @Mock
+    private FilterChain filterChain;
+
+    @InjectMocks
+    private InternalFilter internalFilter;
+
+    @Test
+    @DisplayName("localhost(IPv4)에서 internal API 요청 시 필터를 통과한다")
+    void localhost_ipv4_passes() throws Exception {
+        // Given
+        given(request.getRequestURI()).willReturn("/internal/sse/disconnect");
+        given(request.getRemoteAddr()).willReturn("127.0.0.1");
+
+        // When
+        internalFilter.doFilterInternal(request, response, filterChain);
+
+        // Then
+        verify(filterChain).doFilter(request, response);
+    }
+
+    @Test
+    @DisplayName("localhost(IPv6)에서 internal API 요청 시 필터를 통과한다")
+    void localhost_ipv6_passes() throws Exception {
+        // Given
+        given(request.getRequestURI()).willReturn("/internal/sse/disconnect");
+        given(request.getRemoteAddr()).willReturn("0:0:0:0:0:0:0:1");
+
+        // When
+        internalFilter.doFilterInternal(request, response, filterChain);
+
+        // Then
+        verify(filterChain).doFilter(request, response);
+    }
+
+    @Test
+    @DisplayName("외부 IP에서 internal API 요청 시 403을 반환한다")
+    void external_ip_returns_403() throws Exception {
+        // Given
+        given(request.getRequestURI()).willReturn("/internal/sse/disconnect");
+        given(request.getRemoteAddr()).willReturn("192.168.1.100");
+
+        // When
+        internalFilter.doFilterInternal(request, response, filterChain);
+
+        // Then
+        ArgumentCaptor<Integer> statusCaptor = ArgumentCaptor.forClass(Integer.class);
+        verify(response).sendError(statusCaptor.capture());
+        assertThat(statusCaptor.getValue()).isEqualTo(403);
+        verify(filterChain, never()).doFilter(request, response);
+    }
+
+    @Test
+    @DisplayName("internal 경로가 아닌 요청은 IP에 관계없이 필터를 통과한다")
+    void non_internal_path_passes() throws Exception {
+        // Given
+        given(request.getRequestURI()).willReturn("/admin/organizations");
+
+        // When
+        internalFilter.doFilterInternal(request, response, filterChain);
+
+        // Then
+        verify(filterChain).doFilter(request, response);
+    }
+}

--- a/backend/src/test/java/feedzupzup/backend/internal/controller/InternalControllerTest.java
+++ b/backend/src/test/java/feedzupzup/backend/internal/controller/InternalControllerTest.java
@@ -1,0 +1,35 @@
+package feedzupzup.backend.internal.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+
+import feedzupzup.backend.sse.service.SseService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+@ExtendWith(MockitoExtension.class)
+class InternalControllerTest {
+
+    @Mock
+    private SseService sseService;
+
+    @InjectMocks
+    private InternalController internalController;
+
+    @Test
+    @DisplayName("SSE 전체 연결 해제 요청 시 completeAllEmitters를 호출하고 200 OK를 반환한다")
+    void disconnectAllSse() {
+        // When
+        ResponseEntity<Void> response = internalController.disconnectAllSse();
+
+        // Then
+        verify(sseService).completeAllEmitters();
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    }
+}


### PR DESCRIPTION
## 😉 연관 이슈
- CodedDeploy의 BeforeBlockTraffic에서 SSE 연결을 끊어도, BlockTraffic 이전에 재연결 요청이 와서 deregistration delay 값 이후에 SSE 연결이 종료되는 문제 발생

## 🚀 작업 내용
- SSE 연결 만들 때 flag 값을 사용해 만들도록 설계 수정

